### PR TITLE
feat: Add target attribute to github URL

### DIFF
--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -299,6 +299,16 @@
             Standard icon
           </label>
         </div>
+        <br>
+        <div class="form-group">
+          <label>Select target</label>
+          <select class="form-control" [(ngModel)]="target">
+            <option value="_blank">Blank</option>
+            <option value="_self">Self</option>
+            <option value="_parent">Parent</option>
+            <option value="_top">Top</option>
+          </select>
+        </div>
       </div>
     </div>
     <div class="col-12 col-sm-6 col-md-8">
@@ -312,6 +322,7 @@
           [user]="user || 'angular'"
           [repo]="repo || 'angular'"
           [type]="type"
+          [target]="target"
         >
         </mdo-github-button>
         <ntkme-github-button
@@ -322,6 +333,7 @@
           [repo]="repo || 'angular'"
           [type]="type"
           [standardIcon]="standardIcon"
+          [target]="target"
         >
         </ntkme-github-button>
         <gh-button
@@ -331,6 +343,7 @@
           [repo]="repo || 'angular'"
           [type]="type"
           [standardIcon]="standardIcon"
+          [target]="target"
         >
         </gh-button>
       </div>

--- a/src/app/demo/demo.component.ts
+++ b/src/app/demo/demo.component.ts
@@ -12,6 +12,7 @@ export class DemoComponent {
   repo = '';
   count = false;
   standardIcon = false;
+  target:  '_blank'| '_self' | '_parent' | '_top' = '_self';
   changeSize() {
     this.size = this.size === 'none' ? 'large' : 'none';
   }

--- a/src/lib/gh/gh.component.ts
+++ b/src/lib/gh/gh.component.ts
@@ -7,7 +7,8 @@ import { getRepo, getUser } from '../util';
   selector: 'gh-button',
   template: `
     <div>
-      <a [href]="buttonHref" class="gh-btn" [attr.aria-label]="text + ' on GitHub'">
+      <a [href]="buttonHref" class="gh-btn" [attr.aria-label]="text + ' on GitHub'"
+      [target]="this.target">
         <svg
           version="1.1"
           width="16"
@@ -117,6 +118,13 @@ export class GhButtonComponent implements OnChanges {
   @Input() count = false;
   /** Use the github logo as the icon */
   @Input() standardIcon = false;
+  /** Specifies where to open the linked github URL. */
+  @Input() target:
+    '_blank'  // Opens the linked document in a new window or tab
+  | '_self' // Opens the linked document in the same frame as it was clicked (this is default)
+  | '_parent' //Opens the linked document in the parent frame
+  | '_top'  // Opens the linked document in the full body of the window
+  = '_self'
   text = '';
   buttonHref = '';
   counterHref = '';

--- a/src/lib/gh/gh.component.ts
+++ b/src/lib/gh/gh.component.ts
@@ -8,7 +8,7 @@ import { getRepo, getUser } from '../util';
   template: `
     <div>
       <a [href]="buttonHref" class="gh-btn" [attr.aria-label]="text + ' on GitHub'"
-      [target]="this.target">
+      [target]="target">
         <svg
           version="1.1"
           width="16"

--- a/src/lib/mdo/mdo.component.ts
+++ b/src/lib/mdo/mdo.component.ts
@@ -7,7 +7,7 @@ import { getRepo, getUser } from '../util';
   selector: 'mdo-github-button',
   template: `
     <div class="{{ mainButton }}">
-      <a class="gh-btn" [href]="buttonHref" target="_blank" [attr.aria-label]="text + ' on GitHub'">
+      <a class="gh-btn" [href]="buttonHref" [target]="this.target" [attr.aria-label]="text + ' on GitHub'">
         <span class="gh-ico" aria-hidden="true"></span>
         <span class="gh-text">{{ text }}</span>
       </a>
@@ -93,6 +93,13 @@ export class MdoGithubButtonComponent implements OnChanges {
   @Input() count = false;
   /** Optional flag for using a larger button */
   @Input() size: 'none' | 'large' = 'none';
+  /** Specifies where to open the linked github URL. */
+  @Input() target:
+    '_blank'  // Opens the linked document in a new window or tab
+  | '_self' // Opens the linked document in the same frame as it was clicked (this is default)
+  | '_parent' //Opens the linked document in the parent frame
+  | '_top'  // Opens the linked document in the full body of the window
+  = '_self'
   text = '';
   mainButton = '';
   buttonHref = '';

--- a/src/lib/mdo/mdo.component.ts
+++ b/src/lib/mdo/mdo.component.ts
@@ -7,7 +7,7 @@ import { getRepo, getUser } from '../util';
   selector: 'mdo-github-button',
   template: `
     <div class="{{ mainButton }}">
-      <a class="gh-btn" [href]="buttonHref" [target]="this.target" [attr.aria-label]="text + ' on GitHub'">
+      <a class="gh-btn" [href]="buttonHref" [target]="target" [attr.aria-label]="text + ' on GitHub'">
         <span class="gh-ico" aria-hidden="true"></span>
         <span class="gh-text">{{ text }}</span>
       </a>

--- a/src/lib/ntkme/ntkme.component.ts
+++ b/src/lib/ntkme/ntkme.component.ts
@@ -47,7 +47,7 @@ const svg = {
   template: `
   <div [class.gh-large]="this.size === 'large'">
     <a [href]="buttonHref" class="gh-btn"
-      [attr.aria-label]="text + ' on GitHub'">
+      [attr.aria-label]="text + ' on GitHub'" [target]="this.target">
       <svg version="1.1"
         [attr.width]="svg.width" [attr.height]="svg.height"
         [attr.viewBox]="'0 0 ' + svg.width + ' ' + svg.height"
@@ -150,6 +150,13 @@ export class NtkmeButtonComponent implements OnChanges {
   @Input() size: 'none' | 'large' = 'none';
   /** Use the github logo as the icon */
   @Input() standardIcon = false;
+  /** Specifies where to open the linked github URL. */
+  @Input() target:
+    '_blank'  // Opens the linked document in a new window or tab
+  | '_self' // Opens the linked document in the same frame as it was clicked (this is default)
+  | '_parent' //Opens the linked document in the parent frame
+  | '_top'  // Opens the linked document in the full body of the window
+  = '_self'
   text = '';
   svg: any = {};
   buttonHref = '';

--- a/src/lib/ntkme/ntkme.component.ts
+++ b/src/lib/ntkme/ntkme.component.ts
@@ -47,7 +47,7 @@ const svg = {
   template: `
   <div [class.gh-large]="this.size === 'large'">
     <a [href]="buttonHref" class="gh-btn"
-      [attr.aria-label]="text + ' on GitHub'" [target]="this.target">
+      [attr.aria-label]="text + ' on GitHub'" [target]="target">
       <svg version="1.1"
         [attr.width]="svg.width" [attr.height]="svg.height"
         [attr.viewBox]="'0 0 ' + svg.width + ' ' + svg.height"


### PR DESCRIPTION
Hello @scttcper!

I've created this pull request to be able to specify in the component where to open the GitHub URL.

I think it's a very useful option and one that I've found necessary when I've used your component.

I hope you also find it useful and that it can be merge against master.

Thank you very much for your component.